### PR TITLE
test: Add tests for nested empty keys

### DIFF
--- a/test/fixtures/example-i18next-po.json
+++ b/test/fixtures/example-i18next-po.json
@@ -17,6 +17,11 @@
                 "msgid": "\"\\'\t",
                 "msgstr": ["\"\\'\t"]
             },
+            "Nested empty key##": {
+                "msgctxt": "",
+                "msgid": "Nested empty key##",
+                "msgstr": ["test"]
+            },
             "o1": {
                 "msgctxt": "",
                 "msgid": "o1",

--- a/test/fixtures/example-i18next.json
+++ b/test/fixtures/example-i18next.json
@@ -5,6 +5,9 @@
   "o3-õäöü": "t3-žš",
   "test": "test",
   "\"\\'\t": "\"\\'\t",
+  "Nested empty key": {
+    "": "test"
+  },
   "co1_c1": "ct1",
   "co2-1_c2": "ct2-1",
   "co2-1_c2_plural": "ct2-2",

--- a/test/fixtures/example-i18next.po
+++ b/test/fixtures/example-i18next.po
@@ -26,6 +26,9 @@ msgstr "test"
 msgid "\"\\'\t"
 msgstr "\"\\'\t"
 
+msgid "Nested empty key##"
+msgstr "test"
+
 msgctxt "c1"
 msgid "co1"
 msgstr "ct1"


### PR DESCRIPTION
This PR adds tests for the case described in https://github.com/locize/gettext-converter/issues/9.

The tests are obviously failing, code needs to be updated in order to make them green again.

#### Checklist

- [ ] only relevant code is changed (make a diff before you submit the PR)
- [ ] run tests `npm run test`
- [ ] tests are included
- [ ] documentation is changed or added